### PR TITLE
Add underive

### DIFF
--- a/src/clj-jvm/src/generator/core.clj
+++ b/src/clj-jvm/src/generator/core.clj
@@ -712,7 +712,7 @@
                       ["Dispatch" :cmds '[get-method methods]]
                       ["Remove" :cmds '[remove-method remove-all-methods]]
                       ["Prefer" :cmds '[prefer-method prefers]]
-                      ["Relation" :cmds '[derive isa? parents ancestors
+                      ["Relation" :cmds '[derive underive isa? parents ancestors
                                           descendants make-hierarchy]]]
               ]
              [:box "green"


### PR DESCRIPTION
Multimethod section mentions derive but not underive. (This is the only multimethod-related function omitted from the cheatsheet AFAIK.)