### PR TITLE
Clojure's Lists and Vectors implement Java.util.List not java.util.Ve…

### DIFF
--- a/src/clj-jvm/src/generator/core.clj
+++ b/src/clj-jvm/src/generator/core.clj
@@ -288,10 +288,10 @@
                            :html "Lists (conj, pop, &amp; peek at beginning)"}
               :table [["Create" :cmds '["()" list list*]]
                       ["Examine" :cmds '[first nth peek
-                                         {:latex "\\href{https://docs.oracle.com/javase/8/docs/api/java/util/Vector.html\\#indexOf-java.lang.Object-}{.indexOf}"
-                                          :html "<a href=\"https://docs.oracle.com/javase/8/docs/api/java/util/Vector.html#indexOf-java.lang.Object-\">.indexOf</a>"}
-                                         {:latex "\\href{https://docs.oracle.com/javase/8/docs/api/java/util/Vector.html\\#lastIndexOf-java.lang.Object-}{.lastIndexOf}"
-                                          :html "<a href=\"https://docs.oracle.com/javase/8/docs/api/java/util/Vector.html#lastIndexOf-java.lang.Object-\">.lastIndexOf</a>"}
+                                         {:latex "\\href{https://docs.oracle.com/javase/8/docs/api/java/util/List.html\\#indexOf-java.lang.Object-}{.indexOf}"
+                                          :html "<a href=\"https://docs.oracle.com/javase/8/docs/api/java/util/List.html#indexOf-java.lang.Object-\">.indexOf</a>"}
+                                         {:latex "\\href{https://docs.oracle.com/javase/8/docs/api/java/util/List.html\\#lastIndexOf-java.lang.Object-}{.lastIndexOf}"
+                                          :html "<a href=\"https://docs.oracle.com/javase/8/docs/api/java/util/List.html#lastIndexOf-java.lang.Object-\">.lastIndexOf</a>"}
                                          ]]
                       [{:html "'Change'", :latex "`Change'"}
                        :cmds '[cons conj rest pop]]
@@ -311,10 +311,10 @@
                                          {:latex " \\cmd{my-vec idx)}",
                                           :html " my-vec idx)</code>"}
                                          get peek
-                                         {:latex "\\href{https://docs.oracle.com/javase/8/docs/api/java/util/Vector.html\\#indexOf-java.lang.Object-}{.indexOf}"
-                                          :html "<a href=\"https://docs.oracle.com/javase/8/docs/api/java/util/Vector.html#indexOf-java.lang.Object-\">.indexOf</a>"}
-                                         {:latex "\\href{https://docs.oracle.com/javase/8/docs/api/java/util/Vector.html\\#lastIndexOf-java.lang.Object-}{.lastIndexOf}"
-                                          :html "<a href=\"https://docs.oracle.com/javase/8/docs/api/java/util/Vector.html#lastIndexOf-java.lang.Object-\">.lastIndexOf</a>"}
+                                         {:latex "\\href{https://docs.oracle.com/javase/8/docs/api/java/util/List.html\\#indexOf-java.lang.Object-}{.indexOf}"
+                                          :html "<a href=\"https://docs.oracle.com/javase/8/docs/api/java/util/List.html#indexOf-java.lang.Object-\">.indexOf</a>"}
+                                         {:latex "\\href{https://docs.oracle.com/javase/8/docs/api/java/util/List.html\\#lastIndexOf-java.lang.Object-}{.lastIndexOf}"
+                                          :html "<a href=\"https://docs.oracle.com/javase/8/docs/api/java/util/List.html#lastIndexOf-java.lang.Object-\">.lastIndexOf</a>"}
                                          ]]
                       [{:html "'Change'", :latex "`Change'"}
                        :cmds '[assoc assoc-in pop subvec replace conj rseq


### PR DESCRIPTION
java.util.Vector has an overload of (last)indexOf that isn't part of java.util.List. It's shown on the page that is currently linked  from the cheatsheet and makes it seem like you can use that overload with a Clojure List or Vector (but you can't).